### PR TITLE
pep8, trailing whitespaces and tox:

### DIFF
--- a/example/posts.yaml
+++ b/example/posts.yaml
@@ -11,7 +11,7 @@ body: >
     to emulate a weblog. Of course, to save on time and effort, all the posts
     are pregenerated, and the application is just displaying them. But still,
     it gives people a chance to see how themes are implemented.
-    
+
     There are some templates by default, but they aren't particularly shiny.
     You will want to set a theme if you want the blog to look good.
 
@@ -24,16 +24,16 @@ body: >
     With the Theme Sandbox, probably the easiest way to create a theme is just
     to drop it in the "themes/" folder. You can set THEME_PATHS in the
     configuration, but that is still the easiest.
-    
+
     To actually create a theme, you will need to check the manual for details.
     But it essentially boils down to:
-    
+
     An info.json file that contains metadata about the theme,
-    
+
     A templates/ folder that contains the theme's Jinja2 templates.
-    
+
     A static/ folder containing static files to be served.
-    
+
     A license.txt file (optional) containing the theme's complete license.
 
 ---
@@ -46,7 +46,7 @@ body: >
     I didn't implement all its features, like options for themes, simply
     because those are tied in to Zine's particular mode of configuration, and
     applications will probably have their own.
-    
+
     One person asked if it was inspired by Deliverance. I looked it up, and
     thought that it looked confusing. But basically, the differences are that
     Flask-Themes is for single applications, Deliverance is for multiple
@@ -61,23 +61,23 @@ created: 2010-07-01 11:00:00
 title: Templates
 body: >
     The templates used by this site are:
-    
+
     layout.html, which should have a "body" block and a "head" block (where
     "head" is in the HTML head element), and should expect an exported
     variable named "title" that is the page's title.
-    
+
     index.html, which accepts a "posts" variable that contains three posts.
-    
+
     _helpers.html, which exports a "link_to" macro that takes a caption, an
     endpoint, and keyword arguments.
-    
+
     archive.html, which accepts a "posts" variable that contains *all* of the
     posts.
-    
+
     post.html, which accepts a single "post".
-    
+
     about.html, which accepts "text", the about text as Markup.
-    
+
     themes.html, which accepts a list of themes and should create links to
     "settheme" for each of them.
 
@@ -90,6 +90,6 @@ body: >
     The blog probably seems pretty small to you. And that's the idea - have a
     dataset just big enough to simulate real-world usage. But if you want, you
     can add more posts.
-    
+
     All the posts are stored in the posts.yaml file. You can add them there.
     Slugs must be unique, but that's about the only restriction.

--- a/example/templates/layout.html
+++ b/example/templates/layout.html
@@ -7,14 +7,14 @@
 
 <body>
     <h1>Theme Sandbox</h1>
-    
+
     <p>
         {{ link_to('Index', 'index') }} |
         {{ link_to('Archive', 'archive') }} |
         {{ link_to('About', 'about') }} |
         {{ link_to('Themes', 'themes') }}
     </p>
-    
+
     {% block body %}
     {% endblock body %}
 </body>

--- a/example/themes/calmblue/info.json
+++ b/example/themes/calmblue/info.json
@@ -1,7 +1,7 @@
 {
-    "application": "themesandbox", 
-    "identifier": "calmblue", 
-    "name": "Calm Blue", 
+    "application": "themesandbox",
+    "identifier": "calmblue",
+    "name": "Calm Blue",
     "author": "LeafStorm",
     "description": "A calm, blue theme based on Flaskr.",
     "license": "MIT/X11"

--- a/example/themes/calmblue/templates/layout.html
+++ b/example/themes/calmblue/templates/layout.html
@@ -13,6 +13,6 @@
         {{ link_to('About', 'about') }} |
         {{ link_to('Themes', 'themes') }}
     </div>
-    
+
     {% block body %}{% endblock %}
 </div>

--- a/example/themes/plain/info.json
+++ b/example/themes/plain/info.json
@@ -1,7 +1,7 @@
 {
-    "application": "themesandbox", 
-    "identifier": "plain", 
-    "name": "Plain", 
+    "application": "themesandbox",
+    "identifier": "plain",
+    "name": "Plain",
     "author": "LeafStorm",
     "license": "MIT/X11",
     "description": "An easy-to-read, green-based theme."

--- a/example/themes/plain/templates/layout.html
+++ b/example/themes/plain/templates/layout.html
@@ -14,11 +14,11 @@
             {{ link_to('About', 'about') }} |
             {{ link_to('Themes', 'themes') }}
         </div>
-        
+
         <h1>Theme Sandbox</h1>
-        
+
         <hr class=top>
-        
+
         {% block body %}
         {% endblock body %}
     </div>

--- a/flask_themes/__init__.py
+++ b/flask_themes/__init__.py
@@ -29,7 +29,8 @@ from werkzeug import cached_property
 DOCTYPES = 'html4 html5 xhtml'.split()
 IDENTIFIER = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
 
-containable = lambda i: i if hasattr(i, '__contains__') else tuple(i)
+
+def containable(i): return i if hasattr(i, '__contains__') else tuple(i)
 
 
 def starchain(i):
@@ -42,6 +43,7 @@ class Theme(object):
 
     :param path: The path to the theme directory.
     """
+
     def __init__(self, path):
         #: The theme's root path. All the files in the theme are under this
         #: path.
@@ -138,7 +140,7 @@ class Theme(object):
         return FileSystemLoader(self.templates_path)
 
 
-### theme loaders
+# theme loaders
 
 def list_folders(path):
     """
@@ -216,6 +218,7 @@ class ThemeManager(object):
                     `packaged_themes_loader` and `theme_paths_loader`, in that
                     order.
     """
+
     def __init__(self, app=None, app_identifier=None, loaders=None):
         self.app = app
         if app is not None:
@@ -304,13 +307,14 @@ def get_themes_list():
     return list(ctx.app.theme_manager.list_themes())
 
 
-### theme template loader
+# theme template loader
 
 class ThemeTemplateLoader(BaseLoader):
     """
     This is a template loader that loads templates from the current app's
     loaded themes.
     """
+
     def __init__(self, as_blueprint=False):
         self.as_blueprint = as_blueprint
         BaseLoader.__init__(self)
@@ -344,7 +348,7 @@ def template_exists(templatename):
     return templatename in containable(ctx.app.jinja_env.list_templates())
 
 
-### theme functionality
+# theme functionality
 
 
 themes_blueprint = Blueprint('_themes', __name__, url_prefix='/_themes')

--- a/new-theme.py
+++ b/new-theme.py
@@ -28,7 +28,7 @@ def create_theme(appident, destination):
         author='Your Name'
     )
     os.makedirs(destination)
-    
+
     info_json = os.path.join(destination, 'info.json')
     templates_path = os.path.join(destination, 'templates')
     static_path = os.path.join(destination, 'static')

--- a/tests/test-themes.py
+++ b/tests/test-themes.py
@@ -6,7 +6,8 @@ This tests the Flask-Themes extension.
 from __future__ import with_statement
 import os.path
 from flask import Flask, url_for, render_template
-from flask_themes import (setup_themes, Theme, load_themes_from,
+from flask_themes import (
+    setup_themes, Theme, load_themes_from,
     packaged_themes_loader, theme_paths_loader, ThemeManager, static_file_url,
     template_exists, themes_blueprint, render_theme_template, get_theme,
     get_themes_list)

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,5 @@ basepython = python
 deps =
     flake8
 commands =
-    flake8 flask_theme
+    flake8 flask_theme *.py tests example
 


### PR DESCRIPTION
 - Fix some pep8 cases
 - Remove trailing white spaces under project
 - Include check by flake8 in tox.ini tests, example and *.py files in
   root project